### PR TITLE
feat: top contributors page redirect

### DIFF
--- a/maps/legacy-302-redirects.map
+++ b/maps/legacy-302-redirects.map
@@ -14,6 +14,7 @@
 ~^/support/?$ /news/support;
 ~^/terms/?$ /news/terms-of-service;
 ~^/terms-of-service/?$ /news/terms-of-service;
+~^/top-contributors/?$ /news/freecodecamp-top-contributors;
 
 # misc
 ~^/donation/settings/?$ /donate; 


### PR DESCRIPTION
Added this to the legacy 302 redirects for the time being.

For testing, https://www.freecodecamp.dev/top-contributors/ should redirect to https://www.freecodecamp.dev/news/freecodecamp-top-contributors/.

Partially addresses https://github.com/freeCodeCamp/freeCodeCamp/pull/38348