### PR TITLE
fix: csp for discourse comment embeds

### DIFF
--- a/snippets/common/security.conf
+++ b/snippets/common/security.conf
@@ -4,8 +4,7 @@ add_header X-XSS-Protection "1; mode=block" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "no-referrer-when-downgrade" always;
 #add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googleadservices.com https://googleads.g.doubleclick.net https://www.google.com https://js.stripe.com https://cdnjs.cloudflare.com https://unpkg.com https://*.freecodecamp.org; object-src 'none';" always;
-add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval';" always;
-add_header Content-Security-Policy "frame-ancestors 'self'";
+add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self';" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
 # . files

--- a/snippets/common/security.conf
+++ b/snippets/common/security.conf
@@ -5,6 +5,7 @@ add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "no-referrer-when-downgrade" always;
 #add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googleadservices.com https://googleads.g.doubleclick.net https://www.google.com https://js.stripe.com https://cdnjs.cloudflare.com https://unpkg.com https://*.freecodecamp.org; object-src 'none';" always;
 add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval';" always;
+add_header Content-Security-Policy "frame-ancestors 'self'";
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
 # . files


### PR DESCRIPTION
This change seems to fix the issue @ahmadabdolsaheb and I had with re-enabling the comments for articles on Chinese News. This, along with the current `X-frame-options` allow the Discourse comments to load in Chrome and Firefox. Previously the comments would only load in Firefox.