### PR TITLE
fix: reject unknown hosts

### DIFF
--- a/sites-enabled/00-default.conf
+++ b/sites-enabled/00-default.conf
@@ -3,3 +3,15 @@ server {
   # returning 444 here will immediately drop the connection
   return 444;
 }
+
+# requires Nginx 1.19+
+# the issue here is that simply returning 444 for https doesn't work because 
+# (apparently) Nginx infers the domain name from the certificate and routes
+# accordingly.  Dicussed here
+# https://serverfault.com/a/593668
+# The config below rejects every https connection that does not provide the
+# right hostname
+server {
+    listen               443 ssl;
+    ssl_reject_handshake on;
+}


### PR DESCRIPTION
Explanation's in the comments, but the gist is: drop any https requests for unknown hosts.

One key warning Nginx needs to be at least version 1.19.4.