### PR TITLE
fix: make /espanol proxy handle @'s in urls

### DIFF
--- a/sites-enabled/20-www.freecodecamp.dev.conf
+++ b/sites-enabled/20-www.freecodecamp.dev.conf
@@ -52,11 +52,11 @@ server {
   }
 
   # reverse proxy client (espanol)
-  location ~ ^/espanol(/.*)?$ {
+  location /espanol/ {
     # app specific configs - these configs are applicable on root only
     # include snippets/app/learn.dev.conf;
 
-    proxy_pass http://www-client-dev-espanol/$1$is_args$args;
+    proxy_pass http://www-client-dev-espanol/;
     include snippets/common/proxy-params.conf;
   }
 


### PR DESCRIPTION
The regex capturing of the path could not handle urls like
/espanol/@babel/.  This uses prefix matching instead, which should
send all traffic to /espanol without modifying the request URL.