### PR TITLE
fix: include security headers for font routes

### DIFF
--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -59,6 +59,7 @@ server {
     add_header Cache-Control "public, max-age=31536000, immutable";
   
     proxy_pass http://client-esp/$1;
+    include snippets/common/security.conf;
     include snippets/common/proxy-params.conf;
   }
 
@@ -66,6 +67,7 @@ server {
     add_header Cache-Control "public, max-age=31536000, immutable";
   
     proxy_pass http://client-eng;
+    include snippets/common/security.conf;
     include snippets/common/proxy-params.conf;
   }
 

--- a/sites-enabled/20-www.freecodecamp.dev.conf
+++ b/sites-enabled/20-www.freecodecamp.dev.conf
@@ -51,6 +51,7 @@ server {
     include snippets/app/learn.dev.conf;
 
     proxy_pass http://client-eng;
+    include snippets/common/security.conf;
     include snippets/common/proxy-params.conf;
   }
   
@@ -60,6 +61,7 @@ server {
     add_header Cache-Control "public, max-age=31536000, immutable";
   
     proxy_pass http://client-esp/$1;
+    include snippets/common/security.conf;
     include snippets/common/proxy-params.conf;
   }
 


### PR DESCRIPTION
I'm not sure why the headers were not being applied, but including them
inside the location block works.

This includes deny all for dot files, and I confirmed that that was not
affected

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
