### PR TITLE
fix(news): handle Ghost specific paths

### DIFF
--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -124,9 +124,19 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
-  # reverse proxy news
+  # reverse proxy news - Ghost
+  location ~ ^/news/(ghost|content|p)(/.*)?$ {
+    if (-f /etc/nginx/maintenance/NEWS-ENG.txt) {
+      return 503;
+    }
+    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
+    proxy_pass http://news-eng;
+    include snippets/common/proxy-params.conf;
+  }
+  
+  # reverse proxy news - JAMStack
   location /news {
-    if (-f /etc/nginx/maintenance/NEWS.txt) {
+    if (-f /etc/nginx/maintenance/NEWS-ENG.txt) {
       return 503;
     }
     access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
@@ -161,7 +171,17 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
-  # reverse proxy news (espanol)
+  # reverse proxy news (espanol) - Ghost
+  location ~ ^/espanol/news/(ghost|content|p)(/.*)?$ {
+    if (-f /etc/nginx/maintenance/NEWS-ESP.txt) {
+      return 503;
+    }
+    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
+    proxy_pass http://news-esp;
+    include snippets/common/proxy-params.conf;
+  }
+  
+  # reverse proxy news (espanol) - JAMStack
   location /espanol/news {
     if (-f /etc/nginx/maintenance/NEWS-ESP.txt) {
       return 503;
@@ -202,7 +222,17 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
-  # reverse proxy news (italian)
+  # reverse proxy news (italian) - Ghost
+  location ~ ^/italian/news/(ghost|content|p)(/.*)?$ {
+    if (-f /etc/nginx/maintenance/NEWS-ITA.txt) {
+      return 503;
+    }
+    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
+    proxy_pass http://news-ita;
+    include snippets/common/proxy-params.conf;
+  }
+  
+  # reverse proxy news (italian) - JAMStack
   location /italian/news {
     if (-f /etc/nginx/maintenance/NEWS-ITA.txt) {
       return 503;
@@ -223,22 +253,6 @@ server {
 
     include snippets/common/proxy-params.azure.conf;
   }
-  location /italian/news/ghost {
-    if (-f /etc/nginx/maintenance/NEWS-ITA.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-ita;
-    include snippets/common/proxy-params.conf;
-  }
-  location /italian/news/content {
-    if (-f /etc/nginx/maintenance/NEWS-ITA.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-ita;
-    include snippets/common/proxy-params.conf;
-  }
 
   # reverse proxy client (portuguese)
   location /portuguese/ {
@@ -247,7 +261,17 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
-  # reverse proxy news (portuguese)
+  # reverse proxy news (portuguese) - Ghost
+  location ~ ^/portuguese/news/(ghost|content|p)(/.*)?$ {
+    if (-f /etc/nginx/maintenance/NEWS-POR.txt) {
+      return 503;
+    }
+    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
+    proxy_pass http://news-por;
+    include snippets/common/proxy-params.conf;
+  }
+  
+  # reverse proxy news (portuguese) - JAMStack
   location /portuguese/news {
     if (-f /etc/nginx/maintenance/NEWS-POR.txt) {
       return 503;

--- a/sites-enabled/15-chinese.freecodecamp.org.conf
+++ b/sites-enabled/15-chinese.freecodecamp.org.conf
@@ -57,9 +57,19 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
-  # reverse proxy news (chinese)
+  # reverse proxy news - Ghost
+  location ~ ^/news/(ghost|content|p)(/.*)?$ {
+    if (-f /etc/nginx/maintenance/NEWS-CHN.txt) {
+      return 503;
+    }
+    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
+    proxy_pass http://news-chn;
+    include snippets/common/proxy-params.conf;
+  }
+  
+  # reverse proxy news - JAMStack
   location /news {
-    if (-f /etc/nginx/maintenance/NEWS.txt) {
+    if (-f /etc/nginx/maintenance/NEWS-CHN.txt) {
       return 503;
     }
     access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;


### PR DESCRIPTION
We need a way to handle specific paths for Ghost, i.e., we need access to the Ghost instance. These include:

- [x] `/ghost/*` -- CMS, API, etc.
- [x] `/content` -- Images that we still reference directly within the articles. These will move to some CDN in the future.
- [x] `/p` -- For article previews, these are often shared for review, etc.

P.S: This is live on production for the Italian news, because I did not have another way of testing.