### PR TITLE
fix: reject snippet requests as they already fail

### DIFF
--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -123,6 +123,12 @@ server {
     proxy_pass http://api;
     include snippets/common/proxy-params.conf;
   }
+  
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
 
   # reverse proxy news - Ghost
   location ~ ^/news/(ghost|content|p)(/.*)?$ {
@@ -170,6 +176,12 @@ server {
     proxy_pass http://client-esp/;
     include snippets/common/proxy-params.conf;
   }
+  
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /espanol/news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
 
   # reverse proxy news (espanol) - Ghost
   location ~ ^/espanol/news/(ghost|content|p)(/.*)?$ {
@@ -210,6 +222,12 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /chinese-traditional/news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
+
   # reverse proxy news (chinese-traditional)
   location ~ ^/chinese-traditional/news/?(.*)$ {
     return 302 https://chinese.freecodecamp.org/news/$1;
@@ -220,6 +238,12 @@ server {
     # the trailing hash is needed here.
     proxy_pass http://client-ita/;
     include snippets/common/proxy-params.conf;
+  }
+  
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /italian/news/ghost/api/v3/admin/snippets/ {
+    return 500;
   }
 
   # reverse proxy news (italian) - Ghost
@@ -259,6 +283,12 @@ server {
     # the trailing hash is needed here.
     proxy_pass http://client-por/;
     include snippets/common/proxy-params.conf;
+  }
+
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /portuguese/news/ghost/api/v3/admin/snippets/ {
+    return 500;
   }
 
   # reverse proxy news (portuguese) - Ghost
@@ -304,6 +334,12 @@ server {
   #   include snippets/common/proxy-params.conf;
   # }
 
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /japanese/news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
+
   # reverse proxy news (japanese)
   location /japanese/news {
     if (-f /etc/nginx/maintenance/NEWS-JPN.txt) {
@@ -325,6 +361,12 @@ server {
     # the trailing hash is needed here.
     proxy_pass http://client-ukr/;
     include snippets/common/proxy-params.conf;
+  }
+
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /ukrainian/news/ghost/api/v3/admin/snippets/ {
+    return 500;
   }
 
   # reverse proxy news (ukrainian)

--- a/sites-enabled/20-www.freecodecamp.dev.conf
+++ b/sites-enabled/20-www.freecodecamp.dev.conf
@@ -151,6 +151,12 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
+
   # reverse proxy news
   location /news {
     # Do not index on search engines
@@ -197,6 +203,12 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /espanol/news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
+
   # reverse proxy news (espanol)
   location /espanol/news {
     # Do not index on search engines
@@ -228,6 +240,12 @@ server {
     proxy_pass http://client-cnt/;
     include snippets/common/proxy-params.conf;
   }
+  
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /chinese-traditional/news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
 
   # reverse proxy news (chinese-traditional)
   location ~ ^/chinese-traditional/news/?(.*)$ {
@@ -245,6 +263,12 @@ server {
     # the trailing hash is needed here.
     proxy_pass http://client-ita/;
     include snippets/common/proxy-params.conf;
+  }
+
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /italian/news/ghost/api/v3/admin/snippets/ {
+    return 500;
   }
 
   # reverse proxy news (italian)
@@ -277,6 +301,12 @@ server {
     # the trailing hash is needed here.
     proxy_pass http://client-por/;
     include snippets/common/proxy-params.conf;
+  }
+  
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /portuguese/news/ghost/api/v3/admin/snippets/ {
+    return 500;
   }
 
   # reverse proxy news (portuguese)
@@ -318,6 +348,12 @@ server {
   #   include snippets/common/proxy-params.conf;
   # }
 
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /japanese/news/ghost/api/v3/admin/snippets/ {
+    return 500;
+  }
+
   # reverse proxy news (japanese)
   location /japanese/news {
     # Do not index on search engines
@@ -345,6 +381,12 @@ server {
     # the trailing hash is needed here.
     proxy_pass http://client-ukr/;
     include snippets/common/proxy-params.conf;
+  }
+
+  # This request is causing server errors within ghost, so we reject here to 
+  # reduce load. The ^~ prevents regex locations from matching these urls.
+  location ^~ /ukrainian/news/ghost/api/v3/admin/snippets/ {
+    return 500;
   }
 
   # reverse proxy news (ukrainian)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

@raisedadead we could (probably) cut down on repetition by having a regex at the top of the page, but if we want each language's configs to be close together I think this is the way to go.  I've tested similar configs locally, but not the full blown thing.

I can test on staging when you're happy for me to be poking around in there.

<!-- Feel free to add any additional description of changes below this line -->
