### PR TITLE
fix: handle /subpath-stuff/ when redirecting to subdomains

### DIFF
--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -61,8 +61,8 @@ server {
     add_header Content-Type text/plain;
   }
 
-  # redirect forum to subdomain
-  rewrite ^/forum/(.*)$ https://forum.freecodecamp.org/$1 permanent;
+  # redirect /forum/ and /forum to subdomain
+  rewrite ^/forum(?:|/(.*))$ https://forum.freecodecamp.org/$1 permanent;
 
   # reverse proxy client
   location / {
@@ -163,10 +163,10 @@ server {
   }
 
   # catch common subpath for langs that we have special configs for
-  location ~ ^/spanish/(.*)$ {
+  location ~ ^/spanish(?:|/(.*))$ {
     return 302 https://www.freecodecamp.org/espanol/$1;
   }
-  location ~ ^/chinese/(.*)$ {
+  location ~ ^/chinese(?:|/(.*))$ {
     return 302 https://chinese.freecodecamp.org/$1;
   }
 
@@ -229,7 +229,7 @@ server {
   }
 
   # reverse proxy news (chinese-traditional)
-  location ~ ^/chinese-traditional/news/(.*)$ {
+  location ~ ^/chinese-traditional/news(?:|/(.*))$ {
     return 302 https://chinese.freecodecamp.org/news/$1;
   }
 

--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -62,7 +62,7 @@ server {
   }
 
   # redirect forum to subdomain
-  rewrite ^/forum/?(.*)$ https://forum.freecodecamp.org/$1 permanent;
+  rewrite ^/forum/(.*)$ https://forum.freecodecamp.org/$1 permanent;
 
   # reverse proxy client
   location / {
@@ -163,10 +163,10 @@ server {
   }
 
   # catch common subpath for langs that we have special configs for
-  location ~ ^/spanish/?(.*)$ {
+  location ~ ^/spanish/(.*)$ {
     return 302 https://www.freecodecamp.org/espanol/$1;
   }
-  location ~ ^/chinese/?(.*)$ {
+  location ~ ^/chinese/(.*)$ {
     return 302 https://chinese.freecodecamp.org/$1;
   }
 
@@ -229,7 +229,7 @@ server {
   }
 
   # reverse proxy news (chinese-traditional)
-  location ~ ^/chinese-traditional/news/?(.*)$ {
+  location ~ ^/chinese-traditional/news/(.*)$ {
     return 302 https://chinese.freecodecamp.org/news/$1;
   }
 

--- a/sites-enabled/20-www.freecodecamp.dev.conf
+++ b/sites-enabled/20-www.freecodecamp.dev.conf
@@ -68,7 +68,7 @@ server {
   }
 
   # redirect forum to subdomain
-  rewrite ^/forum/?(.*)$ https://forum.freecodecamp.dev/$1 permanent;
+  rewrite ^/forum/(.*)$ https://forum.freecodecamp.dev/$1 permanent;
 
   # reverse proxy client
   location / {
@@ -180,13 +180,13 @@ server {
   }
 
   # catch common subpath for langs that we have special configs for
-  location ~ ^/spanish/?(.*)$ {
+  location ~ ^/spanish/(.*)$ {
     # Do not index on search engines
     include snippets/common/add-noindex-headers.conf;
 
     return 302 https://www.freecodecamp.dev/espanol/$1;
   }
-  location ~ ^/chinese/?(.*)$ {
+  location ~ ^/chinese/(.*)$ {
     # Do not index on search engines
     include snippets/common/add-noindex-headers.conf;
 
@@ -248,7 +248,7 @@ server {
   }
 
   # reverse proxy news (chinese-traditional)
-  location ~ ^/chinese-traditional/news/?(.*)$ {
+  location ~ ^/chinese-traditional/news/(.*)$ {
     # Do not index on search engines
     include snippets/common/add-noindex-headers.conf;
 

--- a/sites-enabled/20-www.freecodecamp.dev.conf
+++ b/sites-enabled/20-www.freecodecamp.dev.conf
@@ -67,8 +67,8 @@ server {
     return 200 "User-agent: YandexDisallow: /\nUser-agent: *\nDisallow: /";
   }
 
-  # redirect forum to subdomain
-  rewrite ^/forum/(.*)$ https://forum.freecodecamp.dev/$1 permanent;
+  # redirect /forum/ and /forum to subdomain
+  rewrite ^/forum(?:|/(.*))$ https://forum.freecodecamp.dev/$1 permanent;
 
   # reverse proxy client
   location / {
@@ -180,13 +180,13 @@ server {
   }
 
   # catch common subpath for langs that we have special configs for
-  location ~ ^/spanish/(.*)$ {
+  location ~ ^/spanish(?:|/(.*))$ {
     # Do not index on search engines
     include snippets/common/add-noindex-headers.conf;
 
     return 302 https://www.freecodecamp.dev/espanol/$1;
   }
-  location ~ ^/chinese/(.*)$ {
+  location ~ ^/chinese(?:|/(.*))$ {
     # Do not index on search engines
     include snippets/common/add-noindex-headers.conf;
 
@@ -248,7 +248,7 @@ server {
   }
 
   # reverse proxy news (chinese-traditional)
-  location ~ ^/chinese-traditional/news/(.*)$ {
+  location ~ ^/chinese-traditional/news(?:|/(.*))$ {
     # Do not index on search engines
     include snippets/common/add-noindex-headers.conf;
 


### PR DESCRIPTION
Having a regex like /chinese/? meant that the desired paths /chinese/...
matched, but so did paths like /chinese-something-else.

This resulted in freecodecamp.org/chinese-traditional/ getting
redirected to chinese.freecodecamp.org/-traditional

While I was there, I also cleaned up all the other /?'s because I figured the same principle applied.