### PR TITLE
fix: ukrainian ghost redirects

### DIFF
--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -380,6 +380,16 @@ server {
     return 500;
   }
 
+  # reverse proxy news (ukrainian) - Ghost
+  location ~ ^/ukrainian/news/(ghost|content|p)(/.*)?$ {
+    if (-f /etc/nginx/maintenance/NEWS-UKR.txt) {
+      return 503;
+    }
+    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
+    proxy_pass http://news-ukr;
+    include snippets/common/proxy-params.conf;
+  }
+
   # reverse proxy news (ukrainian)
   location /ukrainian/news {
     if (-f /etc/nginx/maintenance/NEWS-UKR.txt) {


### PR DESCRIPTION
This matches arabic and bengali (i.e. it's ready to redirect to the
admin page once /arabic/news goes to 11ty)
