### PR TITLE
refactor: remove unused font locations

### DIFF
--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -88,48 +88,6 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
-  # reverse proxy client fonts
-  # language specific regexes must go first, or the default will be returned
-  location ~* /espanol/(.+\.(woff|ttf))$ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-esp/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* /chinese-traditional/(.+\.(woff|ttf))$ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-cnt/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* /italian/(.+\.(woff|ttf))$ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-ita/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* /portuguese/(.+\.(woff|ttf))$ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-por/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* \.(woff|ttf)$ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-eng;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
   # reverse proxy api
   location /api {
     if (-f /etc/nginx/maintenance/API.txt) {

--- a/sites-enabled/20-www.freecodecamp.dev.conf
+++ b/sites-enabled/20-www.freecodecamp.dev.conf
@@ -97,63 +97,6 @@ server {
     include snippets/common/proxy-params.conf;
   }
 
-  # reverse proxy client fonts
-  # language specific regexes must go first, or the default will be returned
-  location ~* /espanol/(.+\.(woff|ttf))$ {
-    # Do not index on search engines
-    include snippets/common/add-noindex-headers.conf;
-
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-esp/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* /chinese-traditional/(.+\.(woff|ttf))$ {
-    # Do not index on search engines
-    include snippets/common/add-noindex-headers.conf;
-
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-cnt/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* /italian/(.+\.(woff|ttf))$ {
-    # Do not index on search engines
-    include snippets/common/add-noindex-headers.conf;
-
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-ita/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* /portuguese/(.+\.(woff|ttf))$ {
-    # Do not index on search engines
-    include snippets/common/add-noindex-headers.conf;
-
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-por/$1;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
-  location ~* \.(woff|ttf)$ {
-    # Do not index on search engines
-    include snippets/common/add-noindex-headers.conf;
-
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    proxy_pass http://client-eng;
-    include snippets/common/security.conf;
-    include snippets/common/proxy-params.conf;
-  }
-
   # reverse proxy api
   location /api {
     # Do not index on search engines


### PR DESCRIPTION
The headers are now handled by serve.  Or will be after https://github.com/freeCodeCamp/client-config/pull/8 goes in.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
