### PR TITLE
feat: use upstreams from local linode instances

### DIFF
--- a/sites-enabled/10-www.freecodecamp.org.conf
+++ b/sites-enabled/10-www.freecodecamp.org.conf
@@ -176,16 +176,8 @@ server {
     proxy_cache_use_stale  error timeout invalid_header updating
                            http_500 http_502 http_503 http_504;
 
-    proxy_pass https://english.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   english.news.cdn.freecodecamp.org;
-    proxy_set_header Host   english.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # catch common subpath for langs that we have special configs for
-  location ~ ^/spanish(?:|/(.*))$ {
-    return 302 https://www.freecodecamp.org/espanol/$1;
+    proxy_pass http://jms-eng/;
+    include snippets/common/proxy-params.conf;
   }
 
   # reverse proxy client (chinese)
@@ -219,15 +211,17 @@ server {
     access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
 
     proxy_cache NEWS_CACHE_PRD_CHN;
-    proxy_cache_valid 200 1h;
-    proxy_cache_use_stale error timeout invalid_header updating
-    http_500 http_502 http_503 http_504;
+    proxy_cache_valid      200  1h;
+    proxy_cache_use_stale  error timeout invalid_header updating
+                           http_500 http_502 http_503 http_504;
 
-    proxy_pass https://chinese.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host chinese.news.cdn.freecodecamp.org;
-    proxy_set_header Host chinese.news.cdn.freecodecamp.org;
+    proxy_pass http://jms-chn/;
+    include snippets/common/proxy-params.conf;
+  }
 
-    include snippets/common/proxy-params.azure.conf;
+  # catch common subpath for langs that we have special configs for
+  location ~ ^/spanish(?:|/(.*))$ {
+    return 302 https://www.freecodecamp.org/espanol/$1;
   }
 
   # reverse proxy client (espanol)
@@ -265,11 +259,8 @@ server {
     proxy_cache_use_stale  error timeout invalid_header updating
                            http_500 http_502 http_503 http_504;
 
-    proxy_pass https://espanol.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   espanol.news.cdn.freecodecamp.org;
-    proxy_set_header Host   espanol.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
+    proxy_pass http://jms-esp/;
+    include snippets/common/proxy-params.conf;
   }
 
   # reverse proxy client (chinese-traditional)
@@ -325,11 +316,8 @@ server {
     proxy_cache_use_stale  error timeout invalid_header updating
                            http_500 http_502 http_503 http_504;
 
-    proxy_pass https://italian.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   italian.news.cdn.freecodecamp.org;
-    proxy_set_header Host   italian.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
+    proxy_pass http://jms-ita/;
+    include snippets/common/proxy-params.conf;
   }
 
   # reverse proxy client (portuguese)
@@ -367,11 +355,8 @@ server {
     proxy_cache_use_stale  error timeout invalid_header updating
                            http_500 http_502 http_503 http_504;
 
-    proxy_pass https://portuguese.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   portuguese.news.cdn.freecodecamp.org;
-    proxy_set_header Host   portuguese.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
+    proxy_pass http://jms-por/;
+    include snippets/common/proxy-params.conf;
   }
 
   # reverse proxy client (japanese)
@@ -409,11 +394,8 @@ server {
     proxy_cache_use_stale  error timeout invalid_header updating
                            http_500 http_502 http_503 http_504;
 
-    proxy_pass https://japanese.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   japanese.news.cdn.freecodecamp.org;
-    proxy_set_header Host   japanese.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
+    proxy_pass http://jms-jpn/;
+    include snippets/common/proxy-params.conf;
   }
 
   # reverse proxy client (ukrainian)
@@ -451,198 +433,8 @@ server {
     proxy_cache_use_stale  error timeout invalid_header updating
                            http_500 http_502 http_503 http_504;
 
-    proxy_pass https://ukrainian.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host ukrainian.news.cdn.freecodecamp.org;
-    proxy_set_header Host ukrainian.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (arabic)
-  # TEMPORARY redirect to English learn
-  location /arabic {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /arabic/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-ara/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /arabic/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (arabic) - Ghost
-  location ~ ^/arabic/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-ARA.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-ara;
+    proxy_pass http://jms-ukr/;
     include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (arabic) - JAMStack
-  location /arabic/news {
-    if (-f /etc/nginx/maintenance/NEWS-ARA.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_ARA;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass https://arabic.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   arabic.news.cdn.freecodecamp.org;
-    proxy_set_header Host   arabic.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (bengali)
-  # TEMPORARY redirect to English learn
-  location /bengali {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /bengali/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-ben/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /bengali/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (bengali) - Ghost
-  location ~ ^/bengali/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-BEN.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-ben;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (bengali) - JAMStack
-  location /bengali/news {
-    if (-f /etc/nginx/maintenance/NEWS-BEN.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_BEN;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass https://bengali.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   bengali.news.cdn.freecodecamp.org;
-    proxy_set_header Host   bengali.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (urdu)
-  # TEMPORARY redirect to English learn
-  location /urdu {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /urdu/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-urd/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /urdu/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (urdu) - Ghost
-  location ~ ^/urdu/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-URD.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-urd;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (urdu) - JAMStack
-  location /urdu/news {
-    if (-f /etc/nginx/maintenance/NEWS-URD.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_URD;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass https://urdu.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   urdu.news.cdn.freecodecamp.org;
-    proxy_set_header Host   urdu.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (hindi)
-  # TEMPORARY redirect to English learn
-  location /hindi {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /hindi/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-hin/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /hindi/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (hindi) - Ghost
-  location ~ ^/hindi/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-HIN.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-hin;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (hindi) - JAMStack
-  location /hindi/news {
-    if (-f /etc/nginx/maintenance/NEWS-HIN.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_HIN;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass http://news-hin;
-    include snippets/common/proxy-params.conf;
-
-    # proxy_pass https://hindi.news.cdn.freecodecamp.org/;
-    # proxy_set_header X-Forwarded-Host   hindi.news.cdn.freecodecamp.org;
-    # proxy_set_header Host   hindi.news.cdn.freecodecamp.org;
-
-    # include snippets/common/proxy-params.azure.conf;
   }
 
   # reverse proxy client (korean)
@@ -684,338 +476,8 @@ server {
     proxy_cache_use_stale  error timeout invalid_header updating
                            http_500 http_502 http_503 http_504;
 
-    proxy_pass https://korean.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   korean.news.cdn.freecodecamp.org;
-    proxy_set_header Host   korean.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (turkish)
-  # TEMPORARY redirect to English learn
-  location /turkish {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /turkish/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-tur/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /turkish/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (turkish) - Ghost
-  location ~ ^/turkish/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-TUR.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-tur;
+    proxy_pass http://jms-kor/;
     include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (turkish) - JAMStack
-  location /turkish/news {
-    if (-f /etc/nginx/maintenance/NEWS-TUR.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_TUR;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass http://news-tur;
-    include snippets/common/proxy-params.conf;
-
-    # proxy_pass https://turkish.news.cdn.freecodecamp.org/;
-    # proxy_set_header X-Forwarded-Host   turkish.news.cdn.freecodecamp.org;
-    # proxy_set_header Host   turkish.news.cdn.freecodecamp.org;
-
-    # include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (french)
-  # TEMPORARY redirect to English learn
-  location /french {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /french/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-fre/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /french/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (french) - Ghost
-  location ~ ^/french/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-FRE.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-fre;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (french) - JAMStack
-  location /french/news {
-    if (-f /etc/nginx/maintenance/NEWS-FRE.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_FRE;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass https://french.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   french.news.cdn.freecodecamp.org;
-    proxy_set_header Host   french.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (swahili)
-  # TEMPORARY redirect to English learn
-  location /swahili {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /swahili/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-swa/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /swahili/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (swahili) - Ghost
-  location ~ ^/swahili/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-SWA.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-swa;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (swahili) - JAMStack
-  location /swahili/news {
-    if (-f /etc/nginx/maintenance/NEWS-SWA.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_SWA;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass https://swahili.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   swahili.news.cdn.freecodecamp.org;
-    proxy_set_header Host   swahili.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (indonesian)
-  # TEMPORARY redirect to English learn
-  location /indonesian {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /indonesian/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-ind/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /indonesian/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (indonesian) - Ghost
-  location ~ ^/indonesian/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-IND.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-ind;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (indonesian) - JAMStack
-  location /indonesian/news {
-    if (-f /etc/nginx/maintenance/NEWS-IND.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_IND;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass https://indonesian.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   indonesian.news.cdn.freecodecamp.org;
-    proxy_set_header Host   indonesian.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (vietnamese)
-  # TEMPORARY redirect to English learn
-  location /vietnamese {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /vietnamese/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-vie/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /vietnamese/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (vietnamese) - Ghost
-  location ~ ^/vietnamese/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-VIE.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-vie;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (vietnamese) - JAMStack
-  location /vietnamese/news {
-    if (-f /etc/nginx/maintenance/NEWS-VIE.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_VIE;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass http://news-vie;
-    include snippets/common/proxy-params.conf;
-
-    # proxy_pass https://vietnamese.news.cdn.freecodecamp.org/;
-    # proxy_set_header X-Forwarded-Host   vietnamese.news.cdn.freecodecamp.org;
-    # proxy_set_header Host   vietnamese.news.cdn.freecodecamp.org;
-
-    # include snippets/common/proxy-params.azure.conf;
-  }
-
-  # reverse proxy client (haitian)
-  # TEMPORARY redirect to English learn
-  location /haitian {
-    return 302 https://www.freecodecamp.org/;
-  }
-  # location /haitian/ {
-  #   # the trailing hash is needed here.
-  #   proxy_pass http://client-hat/;
-  #   include snippets/common/proxy-params.conf;
-  # }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /haitian/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (haitian) - Ghost
-  location ~ ^/haitian/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-HAT.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-hat;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (haitian) - JAMStack
-  location /haitian/news {
-    if (-f /etc/nginx/maintenance/NEWS-HAT.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_HAT;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass http://news-hat;
-    include snippets/common/proxy-params.conf;
-
-    # proxy_pass https://haitian.news.cdn.freecodecamp.org/;
-    # proxy_set_header X-Forwarded-Host   haitian.news.cdn.freecodecamp.org;
-    # proxy_set_header Host   haitian.news.cdn.freecodecamp.org;
-
-    # include snippets/common/proxy-params.azure.conf;
-  }
-
-    # reverse proxy client (german)
-  location /german/ {
-    # the trailing hash is needed here.
-    proxy_pass http://client-ger/;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # This request is causing server errors within ghost, so we reject here to
-  # reduce load. The ^~ prevents regex locations from matching these urls.
-  location ^~ /german/news/ghost/api/v3/admin/snippets/ {
-    return 500;
-  }
-
-  # reverse proxy news (german) - Ghost
-  location ~ ^/german/news/(ghost|content|p)(/.*)?$ {
-    if (-f /etc/nginx/maintenance/NEWS-GER.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-    proxy_pass http://news-ger;
-    include snippets/common/proxy-params.conf;
-  }
-
-  # reverse proxy news (german) - JAMStack
-  location /german/news {
-    if (-f /etc/nginx/maintenance/NEWS-GER.txt) {
-      return 503;
-    }
-    access_log /var/log/nginx/access.log combined if=$log_4xx_5xx;
-
-    proxy_cache            NEWS_CACHE_PRD_GER;
-    proxy_cache_valid      200  1h;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                           http_500 http_502 http_503 http_504;
-
-    proxy_pass https://german.news.cdn.freecodecamp.org/;
-    proxy_set_header X-Forwarded-Host   german.news.cdn.freecodecamp.org;
-    proxy_set_header Host   german.news.cdn.freecodecamp.org;
-
-    include snippets/common/proxy-params.azure.conf;
   }
 
   location /partners {


### PR DESCRIPTION
This switches the upstreams to local linode instances instead of ACI. As a side-effect removing retired languages until we spin them back up
