### PR TITLE
fix: usernames starting with redirects in 301 and 302 maps

### DIFF
--- a/maps/legacy-301-redirects.map
+++ b/maps/legacy-301-redirects.map
@@ -9,7 +9,8 @@
 ~^/agile/?$ /;
 ~^/all-stories/?$ /;
 ~^/chat/?$ https://gitter.im/FreeCodeCamp/FreeCodeCamp;
-~^/field-guide/?(.*)?$ /;
+~^/field-guide/?$ /;
+~^/field-guide/(.+)/?$ /;
 ~^/how-nonprofit-projects-work/?$ /;
 ~^/learn-to-code/?$ /learn;
 ~*^/nonprofits(-form)?/?$ /;

--- a/maps/legacy-302-redirects.map
+++ b/maps/legacy-302-redirects.map
@@ -24,5 +24,7 @@
 ~^/welcome/?$ /;
 ~^/map/?$ /learn;
 ~^/map-aside/?$ /learn;
-~^/videos/? /learn;
-~^/wiki/? /learn;
+~^/videos/?$ /learn;
+~^/videos/(.+)/?$ /learn;
+~^/wiki/?$ /learn;
+~^/wiki/(.+)/?$ /learn;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
We had someone write into support recently with a username starting with "wiki", so when they tried to visit their public profile they were redirected to `/learn`.

These changes should should prevent that, and should only match requests like `/wiki`, `/wiki/`, or `/wiki/some-path`.

We could use more complex regex like `^\/wiki(\/(.+)?)?$`, but I figure this makes it a little easier to see what's going on with some of these redirects.

I can follow up with another PR to `shared/config/constants.ts` in the main repo to make sure that all of these legacy paths are in the blocked usernames array. I can also check the DB to make sure that no one has a username matching any of these legacy redirects.

@raisedadead, do these changes look reasonable to you?